### PR TITLE
fix: remove unknown properties for TwitterSummaryLargeImage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,8 +40,6 @@ export const metadata = {
   // Twitter
   twitter: {
     card: "summary_large_image",
-    domain: "jschile.org",
-    url,
     title,
     description,
     images,


### PR DESCRIPTION
## Summary
- By mistake, twitter metadata includes "domain" & "URL". These are not known properties for Twitter definition. You can check: https://github.com/vercel/next.js/blob/3248ee71c8e3b4c329e60aec9d8f550612a9ab0a/packages/next/src/lib/metadata/types/twitter-types.ts#L25